### PR TITLE
feat: provide additional methods to exhaust list (PL-000)

### DIFF
--- a/src/chargebee-resource.types.ts
+++ b/src/chargebee-resource.types.ts
@@ -48,13 +48,5 @@ export type ResolveResultReturn<T extends ResourceResult> = {
     : never;
 };
 
-type ListOptions = { options: { exhaust: boolean } };
-
-export type AddListOptions<T> = T extends (...args: infer Args) => infer R
-  ? (...args: Args | [...Args, ListOptions]) => R
-  : never;
-
-export const isListOptions = (arg: unknown): arg is ListOptions =>
-  typeof arg === "object" &&
-  "options" in arg &&
-  typeof arg.options === "object";
+export const isListOffsetOption = (arg: unknown): arg is { offset: string } =>
+  typeof arg === "object" && "offset" in arg && typeof arg.offset === "string";


### PR DESCRIPTION
Provides additional options for lists for how to consume the results.

```ts
subscription.list(...) // what we have today, returns items and offset
subscription.list.all(...) // exhaust and return array of items
subscription.list.iterate(...) // exhaust but via an iterator
```

Now, depending on the use-case, we can cover it.