### PR TITLE
feat: additional environment options

### DIFF
--- a/src/chargebee.interface.ts
+++ b/src/chargebee.interface.ts
@@ -1,4 +1,11 @@
 export interface ChargebeeModuleOptions {
   site: string;
   apiKey: string;
+  override: {
+    hostSuffix?: string;
+    apiPath?: string;
+    protocol?: "https" | "http";
+    port?: number;
+    timeout?: number;
+  };
 }

--- a/src/chargebee.interface.ts
+++ b/src/chargebee.interface.ts
@@ -1,11 +1,8 @@
 export interface ChargebeeModuleOptions {
   site: string;
   apiKey: string;
-  override: {
-    hostSuffix?: string;
-    apiPath?: string;
-    protocol?: "https" | "http";
-    port?: number;
+  override?: {
+    url?: string;
     timeout?: number;
   };
 }

--- a/src/chargebee.service.ts
+++ b/src/chargebee.service.ts
@@ -22,6 +22,15 @@ function configureChargebee(options: ChargebeeModuleOptions) {
   client.configure({
     site: options.site,
     api_key: options.apiKey,
+    ...(options.override?.hostSuffix
+      ? { hostSuffix: options.override.hostSuffix }
+      : {}),
+    ...(options.override?.apiPath ? { apiPath: options.override.apiPath } : {}),
+    ...(options.override?.protocol
+      ? { protocol: options.override.protocol }
+      : {}),
+    ...(options.override?.port ? { port: options.override.port } : {}),
+    ...(options.override?.timeout ? { timeout: options.override.timeout } : {}),
   });
   return client;
 }

--- a/src/chargebee.service.ts
+++ b/src/chargebee.service.ts
@@ -22,15 +22,19 @@ function configureChargebee(options: ChargebeeModuleOptions) {
   client.configure({
     site: options.site,
     api_key: options.apiKey,
-    ...(options.override?.hostSuffix
-      ? { hostSuffix: options.override.hostSuffix }
-      : {}),
-    ...(options.override?.apiPath ? { apiPath: options.override.apiPath } : {}),
-    ...(options.override?.protocol
-      ? { protocol: options.override.protocol }
-      : {}),
-    ...(options.override?.port ? { port: options.override.port } : {}),
+    ...(options.override?.url ? extractURLOptions(options.override.url) : {}),
     ...(options.override?.timeout ? { timeout: options.override.timeout } : {}),
   });
   return client;
+}
+
+function extractURLOptions(urlStr: string) {
+  const url = new URL(urlStr);
+
+  return {
+    hostSuffix: "." + url.host,
+    apiPath: url.pathname,
+    protocol: url.protocol.replace(":", ""),
+    port: url.port,
+  };
 }


### PR DESCRIPTION
These options are used in the underlying `chargebee-typescript` library to build the request. We can expose them as `override` options if we need to direct the request elsewhere.

References:
- https://github.com/chargebee/chargebee-typescript/blob/master/src/chargebee.ts#L71C18-L71C18
    - Options are extended into `this._env`
- https://github.com/chargebee/chargebee-typescript/blob/master/src/core.ts#L84
    - Options (`_env`) being used
- https://github.com/chargebee/chargebee-typescript/blob/master/src/environment.ts#L4
    - Reference of other options