### PR TITLE
fix: url override replaces site (PL-000)

### DIFF
--- a/src/chargebee.service.ts
+++ b/src/chargebee.service.ts
@@ -20,7 +20,7 @@ export class ChargebeeService extends ChargebeeResourceWrapper {
 function configureChargebee(options: ChargebeeModuleOptions) {
   const client = new ChargeBee();
   client.configure({
-    site: options.site,
+    site: options.override?.url ? "" : options.site,
     api_key: options.apiKey,
     ...(options.override?.url ? extractURLOptions(options.override.url) : {}),
     ...(options.override?.timeout ? { timeout: options.override.timeout } : {}),
@@ -32,7 +32,7 @@ function extractURLOptions(urlStr: string) {
   const url = new URL(urlStr);
 
   return {
-    hostSuffix: "." + url.host,
+    hostSuffix: url.host,
     apiPath: url.pathname,
     protocol: url.protocol.replace(":", ""),
     port: url.port,


### PR DESCRIPTION
Previously, the overwritten URL would still need a valid `site`, which needed to be a sub domain.
This change makes it so the overwritten URL is exactly what it will be, no need to have `site`.