### PR TITLE
fix: use hostname instead of host to remove any port references on it (PL-000)

### DIFF
--- a/src/chargebee.utils.ts
+++ b/src/chargebee.utils.ts
@@ -18,7 +18,7 @@ export function extractURLOptions(urlStr: string) {
   const url = new URL(urlStr);
 
   return {
-    hostSuffix: url.host,
+    hostSuffix: url.hostname,
     apiPath: url.pathname,
     protocol: url.protocol.replace(":", ""),
     port: url.port,


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-XXX**

### Brief description. What is this change?
If we pass an override url like `http://billing-api:8080` the `url.host` will look like `billing-api:8080` which will mess up things. We should instead use the `url.hostname` which looks like `billing-api`.
